### PR TITLE
Performance optimizations for crystal destruction handling

### DIFF
--- a/src/main/java/com/deathmotion/marlowcrystal/MarlowCrystal.java
+++ b/src/main/java/com/deathmotion/marlowcrystal/MarlowCrystal.java
@@ -8,13 +8,13 @@ import net.fabricmc.api.EnvType;
 import net.fabricmc.api.Environment;
 import net.fabricmc.fabric.api.networking.v1.PayloadTypeRegistry;
 
-@Getter
 @Environment(EnvType.CLIENT)
 public class MarlowCrystal implements ClientModInitializer {
 
     @Getter
     private static MarlowCrystal instance;
 
+    @Getter
     private Logger logger;
 
     @Override

--- a/src/main/java/com/deathmotion/marlowcrystal/mixin/ClientConnectionMixin.java
+++ b/src/main/java/com/deathmotion/marlowcrystal/mixin/ClientConnectionMixin.java
@@ -6,6 +6,7 @@ import net.minecraft.network.Connection;
 import net.minecraft.network.protocol.Packet;
 import net.minecraft.network.protocol.game.ServerboundInteractPacket;
 import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Unique;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
@@ -13,12 +14,16 @@ import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 @Mixin(Connection.class)
 public class ClientConnectionMixin {
 
+    @Unique
+    private InteractHandler cachedHandler;
+
     @Inject(method = "send(Lnet/minecraft/network/protocol/Packet;)V", at = @At("HEAD"))
     private void onPacketSend(Packet<?> packet, CallbackInfo ci) {
-        Minecraft client = Minecraft.getInstance();
-
         if (packet instanceof ServerboundInteractPacket interactionPacket) {
-            interactionPacket.dispatch(new InteractHandler(client));
+            if (cachedHandler == null) {
+                cachedHandler = new InteractHandler(Minecraft.getInstance());
+            }
+            interactionPacket.dispatch(cachedHandler);
         }
     }
 }

--- a/src/main/java/com/deathmotion/marlowcrystal/mixin/ServerOptOut.java
+++ b/src/main/java/com/deathmotion/marlowcrystal/mixin/ServerOptOut.java
@@ -14,6 +14,6 @@ public class ServerOptOut {
 
     @Inject(at = @At("TAIL"), method = "handleLogin")
     private void sendInfoPackage(ClientboundLoginPacket packet, CallbackInfo ci) {
-        ClientPlayNetworking.send(new OptOutPacket());
+        ClientPlayNetworking.send(OptOutPacket.INSTANCE);
     }
 }

--- a/src/main/java/com/deathmotion/marlowcrystal/packets/OptOutPacket.java
+++ b/src/main/java/com/deathmotion/marlowcrystal/packets/OptOutPacket.java
@@ -1,6 +1,5 @@
 package com.deathmotion.marlowcrystal.packets;
 
-import io.netty.buffer.Unpooled;
 import net.minecraft.network.RegistryFriendlyByteBuf;
 import net.minecraft.network.codec.StreamCodec;
 import net.minecraft.network.protocol.common.custom.CustomPacketPayload;
@@ -9,18 +8,22 @@ import org.jetbrains.annotations.NotNull;
 
 public class OptOutPacket implements CustomPacketPayload {
     public static final CustomPacketPayload.Type<OptOutPacket> TYPE = new CustomPacketPayload.Type<>(ResourceLocation.tryParse("mco"));
+    public static final OptOutPacket INSTANCE = new OptOutPacket();
 
     public static final StreamCodec<RegistryFriendlyByteBuf, OptOutPacket> STREAM_CODEC = new StreamCodec<>() {
         @Override
         public void encode(RegistryFriendlyByteBuf buffer, OptOutPacket optOutPacket) {
-            Unpooled.buffer();
+            // No data to encode
         }
 
         @Override
         public @NotNull OptOutPacket decode(RegistryFriendlyByteBuf buffer) {
-            return new OptOutPacket();
+            return INSTANCE;
         }
     };
+
+    private OptOutPacket() {
+    }
 
     @Override
     public @NotNull Type<OptOutPacket> type() {

--- a/src/main/java/com/deathmotion/marlowcrystal/util/Logger.java
+++ b/src/main/java/com/deathmotion/marlowcrystal/util/Logger.java
@@ -4,22 +4,22 @@ import com.mojang.logging.LogUtils;
 
 public class Logger {
 
-    private final static String PREFIX = "[MarlowCrystal] ";
+    private static final String PREFIX = "[MarlowCrystal] ";
     private final org.slf4j.Logger logger = LogUtils.getLogger();
 
-    public final void info(final String message) {
-        logger.info(PREFIX + "{}", message);
+    public void info(String message) {
+        logger.info("{}{}", PREFIX, message);
     }
 
-    public final void warn(final String message) {
-        logger.warn(PREFIX + "{}", message);
+    public void warn(String message) {
+        logger.warn("{}{}", PREFIX, message);
     }
 
-    public final void error(final String message) {
-        logger.error(PREFIX + "{}", message);
+    public void error(String message) {
+        logger.error("{}{}", PREFIX, message);
     }
 
-    public final void debug(final String message) {
-        logger.debug(PREFIX + "{}", message);
+    public void debug(String message) {
+        logger.debug("{}{}", PREFIX, message);
     }
 }


### PR DESCRIPTION
- Optimized damage calculation with fast-path check for typical scenarios
- Cached InteractHandler instance to reduce object allocations
- Fixed memory leak in OptOutPacket by removing unused buffer creation
- Implemented singleton pattern for OptOutPacket
- Improved logging performance with proper SLF4J parameterization
- Replaced array workaround with reusable DoubleAdder in weapon damage calculation